### PR TITLE
Redirect non-HTTPS requests

### DIFF
--- a/client/webserver.js
+++ b/client/webserver.js
@@ -8,6 +8,14 @@ app.set('view engine', 'pug');
 
 app.set('views', path.join(__dirname, 'views'));
 
+// Reroute HTTP to HTTPS
+app.use((req, res, next) => {
+    if (req.header('x-forwarded-proto') !== 'https')
+      res.redirect(`https://${req.header('host')}${req.url}`)
+    else
+      next()
+  })
+
 app.get('/', (req, res) => {
     res.render('homepage');
 });


### PR DESCRIPTION
Implementing redirect as shown here: https://jaketrent.com/post/https-redirect-node-heroku/
Closes #107